### PR TITLE
Cast padding to int to prevent PHP warning

### DIFF
--- a/fieldtypes/IncrementFieldType.php
+++ b/fieldtypes/IncrementFieldType.php
@@ -168,7 +168,7 @@ class IncrementFieldType extends BaseFieldType
      */
     private function setPostDate()
     {
-        if (is_null($this->element->postDate)) {
+        if (($this->element == ElementType::Entry) && is_null($this->element->postDate)) {
             $this->element->postDate = new DateTime();
         }
     }

--- a/fieldtypes/IncrementFieldType.php
+++ b/fieldtypes/IncrementFieldType.php
@@ -107,7 +107,7 @@ class IncrementFieldType extends BaseFieldType
         }
 
         // Pad zeroes
-        $value = str_pad($value, $settings->padding, '0', STR_PAD_LEFT);
+        $value = str_pad($value, (int) $settings->padding, '0', STR_PAD_LEFT);
 
         // Add prefix
         $value = craft()->templates->renderObjectTemplate($settings->prefix, $this->element).$value;


### PR DESCRIPTION
If the padding is left blank in the settings for an Increment field, then when an entry containing the field is created or edited, the following PHP warning is shown:

```
str_pad() expects parameter 2 to be long, string given
```

Casting the padding value to an int removes this warning when it is left empty.
